### PR TITLE
Fix routing kit so it returns nonzero values (shadow variable error)

### DIFF
--- a/src/routingkit/CMakeLists.txt
+++ b/src/routingkit/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.13)
 
+if(MSVC)
+  add_compile_options(/W4 /WX)
+else()
+  add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()
+
 #Use the default Julia to find the CxxWrap path
 if(NOT DEFINED JL_CXX_WRAP_PATH)
   execute_process(COMMAND julia "-e" "using CxxWrap; print(CxxWrap.CxxWrapCore.prefix_path())"

--- a/src/routingkit/routingkit.cpp
+++ b/src/routingkit/routingkit.cpp
@@ -2,7 +2,6 @@
 #include <routingkit/contraction_hierarchy.h>
 #include <routingkit/geo_position_to_node.h>
 #include <routingkit/inverse_vector.h>
-#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -47,13 +46,13 @@ std::vector<double> Router::getTravelTime(const double from_lat, const double fr
   unsigned to;
 
   try {
-    const auto from = getNearestNode(from_lat, from_lon, search_radius_m);
+    from = getNearestNode(from_lat, from_lon, search_radius_m);
   } catch (const std::exception &) {
     throw std::runtime_error("No node near start position!");
   }
 
   try {
-    const auto to = getNearestNode(to_lat, to_lon, search_radius_m);
+    to = getNearestNode(to_lat, to_lon, search_radius_m);
   } catch (const std::exception &) {
     throw std::runtime_error("No node near target position!");
   }


### PR DESCRIPTION
Requesting a pull to nickolasclarke:master from nickolasclarke:richard/fix_routing_kit

Write a message for this pull request. The first block
of text is the title and the rest is the description.

Changes:

c2465fd (Richard Barnes, 21 seconds ago)
   Compile with warnings so it doesn't happen again

a30ef9f (Richard Barnes, 31 seconds ago)
   Eliminate shadowed variables in routingkit.cpp